### PR TITLE
User can comment on another post

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem 'rspotify'
 gem "omniauth", "~> 1.9.1"
 gem 'devise_token_auth'
 gem 'omniauth-spotify'
+gem 'active_model_serializers'
 
 group :development, :test do
   gem 'pry-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,6 +37,11 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
+    active_model_serializers (0.10.11)
+      actionpack (>= 4.1, < 6.1)
+      activemodel (>= 4.1, < 6.1)
+      case_transform (>= 0.2)
+      jsonapi-renderer (>= 0.1.1.beta1, < 0.3)
     activejob (6.0.3.4)
       activesupport (= 6.0.3.4)
       globalid (>= 0.3.6)
@@ -63,6 +68,8 @@ GEM
       msgpack (~> 1.0)
     builder (3.2.4)
     byebug (11.1.3)
+    case_transform (0.2)
+      activesupport
     coderay (1.1.3)
     concurrent-ruby (1.1.8)
     coveralls (0.8.23)
@@ -124,6 +131,7 @@ GEM
     i18n (1.8.7)
       concurrent-ruby (~> 1.0)
     json (2.5.1)
+    jsonapi-renderer (0.2.2)
     jwt (2.2.2)
     listen (3.4.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
@@ -300,6 +308,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  active_model_serializers
   bootsnap (>= 1.4.2)
   coveralls
   devise_token_auth

--- a/app/controllers/api/comments_controller.rb
+++ b/app/controllers/api/comments_controller.rb
@@ -1,6 +1,11 @@
 class Api::CommentsController < ApplicationController
   before_action :authenticate_user!, only: [:create]
 
+  def index
+    comments = Comment.all
+    render json: comments, each_serializer: CommentsIndexSerializer
+  end
+
   def create
     comment = current_user.comments.create(comment_params)
     if comment.persisted?

--- a/app/controllers/api/comments_controller.rb
+++ b/app/controllers/api/comments_controller.rb
@@ -1,5 +1,5 @@
 class Api::CommentsController < ApplicationController
-  before_action :authenticate_user!, only: [:create]
+  before_action :authenticate_user!, only: %i[index create]
 
   def create
     comment = current_user.comments.create(comment_params)

--- a/app/controllers/api/comments_controller.rb
+++ b/app/controllers/api/comments_controller.rb
@@ -13,33 +13,6 @@ class Api::CommentsController < ApplicationController
   private
 
   def comment_params
-    params.require(:comment).permit(:content, :post_id, :user_id)
+    params.require(:comment).permit(:content, :post_id)
   end
 end
-
-# RSpec.describe 'POST /api/posts/:post_id/comments', type: :request do
-#   let(:user) { create(:user, email: 'user@new.com') }
-#   let(:user_header) { user.create_new_auth_token }
-#   let!(:post) { create(:post) }
-
-#   describe 'successfully create a comment' do
-#     before do
-#       post "/api/posts/#{post.id}/comments",
-#            params: {
-#              comment: {
-#                content: 'Awesome stuff!'
-#               #  post_id: post.id
-#              }
-#            },
-#            headers: user_header
-#     end
-
-#     it 'is expected to return a 201 status' do
-#       expect(response).to have_http_status 201
-#     end
-
-#     it 'is expected to return the comment that was created' do
-#       expect(post.comments[0]['content']).to eq 'Awesome stuff!'
-#     end
-#   end
-# end

--- a/app/controllers/api/comments_controller.rb
+++ b/app/controllers/api/comments_controller.rb
@@ -1,6 +1,4 @@
 class Api::CommentsController < ApplicationController
-  before_action :authenticate_user!, only: %i[index create]
-
   def index
     comments = Comment.all
     render json: comments, each_serializer: CommentsIndexSerializer

--- a/app/controllers/api/comments_controller.rb
+++ b/app/controllers/api/comments_controller.rb
@@ -1,0 +1,45 @@
+class Api::CommentsController < ApplicationController
+  before_action :authenticate_user!, only: [:create]
+
+  def create
+    comment = current_user.comments.create(comment_params)
+    if comment.persisted?
+      render json: { comment: comment }, status: 201
+    else
+      render json: { message: comment.errors.full_messages.to_sentence }, status: 422
+    end
+  end
+
+  private
+
+  def comment_params
+    params.require(:comment).permit(:content, :post_id, :user_id)
+  end
+end
+
+# RSpec.describe 'POST /api/posts/:post_id/comments', type: :request do
+#   let(:user) { create(:user, email: 'user@new.com') }
+#   let(:user_header) { user.create_new_auth_token }
+#   let!(:post) { create(:post) }
+
+#   describe 'successfully create a comment' do
+#     before do
+#       post "/api/posts/#{post.id}/comments",
+#            params: {
+#              comment: {
+#                content: 'Awesome stuff!'
+#               #  post_id: post.id
+#              }
+#            },
+#            headers: user_header
+#     end
+
+#     it 'is expected to return a 201 status' do
+#       expect(response).to have_http_status 201
+#     end
+
+#     it 'is expected to return the comment that was created' do
+#       expect(post.comments[0]['content']).to eq 'Awesome stuff!'
+#     end
+#   end
+# end

--- a/app/controllers/api/omniauth_callbacks_controller.rb
+++ b/app/controllers/api/omniauth_callbacks_controller.rb
@@ -31,7 +31,7 @@ module Api
       'User'.constantize
     end
 
-    def resource_class
+    def resource_class(mapping = nil)
       if omniauth_params[:resource_class]
         omniauth_params[:resource_class].constantize
       elsif params[:resource_class]

--- a/app/controllers/api/posts_controller.rb
+++ b/app/controllers/api/posts_controller.rb
@@ -1,5 +1,5 @@
 class Api::PostsController < ApplicationController
-  # before_action :authenticate_user!, only: [:index, :create]
+  before_action :authenticate_user!, only: [:index, :create]
 
   def index
     posts = Post.order('created_at DESC')

--- a/app/controllers/api/posts_controller.rb
+++ b/app/controllers/api/posts_controller.rb
@@ -1,6 +1,4 @@
 class Api::PostsController < ApplicationController
-  before_action :authenticate_user!, only: %i[index create]
-
   def index
     posts = Post.order('created_at DESC')
     render json: posts, each_serializer: PostIndexSerializer

--- a/app/controllers/api/posts_controller.rb
+++ b/app/controllers/api/posts_controller.rb
@@ -3,7 +3,7 @@ class Api::PostsController < ApplicationController
 
   def index
     posts = Post.order('created_at DESC')
-    render json: posts, each_serializer: PostIndexSerializer
+    render json: {posts: posts}, each_serializer: PostIndexSerializer
   end
 
   def create

--- a/app/controllers/api/posts_controller.rb
+++ b/app/controllers/api/posts_controller.rb
@@ -1,9 +1,9 @@
 class Api::PostsController < ApplicationController
-  before_action :authenticate_user!, only: [:index, :create]
+  before_action :authenticate_user!, only: %i[index create]
 
   def index
     posts = Post.order('created_at DESC')
-    render json: {posts: posts}, each_serializer: PostIndexSerializer
+    render json: posts, each_serializer: PostIndexSerializer
   end
 
   def create
@@ -11,7 +11,7 @@ class Api::PostsController < ApplicationController
     if post.persisted?
       render json: { message: 'Your post was successfully created!' }, status: 201
     else
-      render json: { message: post.errors.full_messages.to_sentence}, status: 422
+      render json: { message: post.errors.full_messages.to_sentence }, status: 422
     end
   end
 

--- a/app/controllers/api/posts_controller.rb
+++ b/app/controllers/api/posts_controller.rb
@@ -1,5 +1,5 @@
 class Api::PostsController < ApplicationController
-  before_action :authenticate_user!, only: [:index, :create]
+  # before_action :authenticate_user!, only: [:index, :create]
 
   def index
     posts = Post.order('created_at DESC')

--- a/app/controllers/api/posts_controller.rb
+++ b/app/controllers/api/posts_controller.rb
@@ -3,7 +3,7 @@ class Api::PostsController < ApplicationController
 
   def index
     posts = Post.order('created_at DESC')
-    render json: { posts: posts }
+    render json: posts, each_serializer: PostIndexSerializer
   end
 
   def create

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,0 +1,4 @@
+class Comment < ApplicationRecord
+  belongs_to :user
+  belongs_to :post
+end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,4 +1,5 @@
 class Comment < ApplicationRecord
+  validates_presence_of :content
   belongs_to :user
   belongs_to :post
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -2,4 +2,5 @@ class Post < ApplicationRecord
   validates_presence_of :track, :artists, :description
 
   belongs_to :user
+  has_many :comments
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class User < ActiveRecord::Base
   extend Devise::Models
   devise :database_authenticatable, :registerable,
@@ -7,5 +8,5 @@ class User < ActiveRecord::Base
   include DeviseTokenAuth::Concerns::User
 
   has_many :posts
+  has_many :comments
 end
-

--- a/app/serializers/comments_index_serializer.rb
+++ b/app/serializers/comments_index_serializer.rb
@@ -1,0 +1,7 @@
+class CommentsIndexSerializer < ActiveModel::Serializer
+  attributes :id, :content, :user
+
+  def user
+    object.user.uid
+  end
+end

--- a/app/serializers/post_index_serializer.rb
+++ b/app/serializers/post_index_serializer.rb
@@ -1,0 +1,7 @@
+class PostIndexSerializer < ActiveModel::Serializer
+  attributes :id, :track, :artists, :image, :preview, :description, :comments
+
+  def comments
+    object.comments.content
+  end
+end

--- a/app/serializers/post_index_serializer.rb
+++ b/app/serializers/post_index_serializer.rb
@@ -1,5 +1,6 @@
 class PostIndexSerializer < ActiveModel::Serializer
   attributes :id, :track, :artists, :image, :preview, :description, :comments
+  has_many :comments
 
   def comments
     object.comments

--- a/app/serializers/post_index_serializer.rb
+++ b/app/serializers/post_index_serializer.rb
@@ -2,6 +2,6 @@ class PostIndexSerializer < ActiveModel::Serializer
   attributes :id, :track, :artists, :image, :preview, :description, :comments
 
   def comments
-    object.comments.content
+    object.comments
   end
 end

--- a/app/serializers/post_index_serializer.rb
+++ b/app/serializers/post_index_serializer.rb
@@ -1,8 +1,4 @@
 class PostIndexSerializer < ActiveModel::Serializer
-  attributes :id, :track, :artists, :image, :preview, :description, :comments
-  has_many :comments
-
-  def comments
-    object.comments
-  end
+  attributes :id, :track, :artists, :image, :preview, :description
+  has_many :comments, serializer: CommentsIndexSerializer
 end

--- a/app/serializers/post_index_serializer_serializer.rb
+++ b/app/serializers/post_index_serializer_serializer.rb
@@ -1,3 +1,0 @@
-class PostIndexSerializerSerializer < ActiveModel::Serializer
-  attributes :id
-end

--- a/app/serializers/post_index_serializer_serializer.rb
+++ b/app/serializers/post_index_serializer_serializer.rb
@@ -1,0 +1,3 @@
+class PostIndexSerializerSerializer < ActiveModel::Serializer
+  attributes :id
+end

--- a/config/initializers/ams.rb
+++ b/config/initializers/ams.rb
@@ -1,0 +1,1 @@
+ActiveModelSerializers.config.adapter = :json

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,9 +1,11 @@
 Rails.application.routes.draw do
-  mount_devise_token_auth_for 'User',
-  at: 'auth',
-  controllers: { omniauth_callbacks: 'api/omniauth_callbacks'}
+  mount_devise_token_auth_for 'User', 
+  at: 'auth', 
+  controllers: { omniauth_callbacks: 'api/omniauth_callbacks' }
   namespace :api do
-    resources :posts, only: [:index, :create]
+    resources :posts, only: %i[index create] do
+      resources :comments, only: [:create]
+    end
     resources :tracks, only: [:index]
     get 'omniauth_callbacks/spotify'
   end

--- a/db/migrate/20210130144800_create_comments.rb
+++ b/db/migrate/20210130144800_create_comments.rb
@@ -1,0 +1,10 @@
+class CreateComments < ActiveRecord::Migration[6.0]
+  def change
+    create_table :comments do |t|
+      t.text :content
+      t.references :user, null: false, foreign_key: true
+      t.references :post, null: false, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,20 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_29_150958) do
+ActiveRecord::Schema.define(version: 2021_01_30_144800) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "comments", force: :cascade do |t|
+    t.text "content"
+    t.bigint "user_id", null: false
+    t.bigint "post_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["post_id"], name: "index_comments_on_post_id"
+    t.index ["user_id"], name: "index_comments_on_user_id"
+  end
 
   create_table "posts", force: :cascade do |t|
     t.string "track"
@@ -53,4 +63,6 @@ ActiveRecord::Schema.define(version: 2021_01_29_150958) do
     t.index ["uid", "provider"], name: "index_users_on_uid_and_provider", unique: true
   end
 
+  add_foreign_key "comments", "posts"
+  add_foreign_key "comments", "users"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -16,3 +16,8 @@ Post.create(user_id: 2, track: 'Lavender Blush', artists: 'Nobuya Kobori', image
 Post.create(user_id: 3, track: 'Pink Salmon', artists: 'Peewee Longway', image: 'https://i.scdn.co/image/ab67616d0000b273ce38c038198b8666e03c3987', preview: 'https://p.scdn.co/mp3-preview/ccdb95d288576fc8fafa5ac47302e55806740b9f?cid=9165f2ed52ac4632b2c23038c2fbe1d9', description: 'I listen to this while Im eating my pink salmon. So tasty!')
 Post.create(user_id: 4, track: 'Peachpuff', artists: 'Jellymastermen', image: 'https://i.scdn.co/image/ab67616d0000b27331871632e947d529e0f19bdc', preview: 'https://p.scdn.co/mp3-preview/c76c3bae766a2f4e904b59d95b2c946172c0cfa9?cid=9165f2ed52ac4632b2c23038c2fbe1d9', description: 'Peach is one of my favorite fruits, even better when its a puff!')
 Post.create(user_id: 4, track: 'Aliceblue', artists: 'Karl J. Anderson', image: 'https://i.scdn.co/image/ab67616d0000b2739e9d728243e3b8752da1df8e', preview: 'https://p.scdn.co/mp3-preview/aee0d9d2203158226d012fff8e56ad86591a165c?cid=9165f2ed52ac4632b2c23038c2fbe1d9', description: 'I listen to this song when I feel blue(My name is Alice)')
+
+Comment.create(user_id: 4, post_id: 1, content: 'Wow what a lovely song. This song reminds me of good old days!')
+Comment.create(user_id: 1, post_id: 1, content: 'I know! All the Swedish love this song!')
+Comment.create(user_id: 3, post_id: 2, content: 'Papaya Whip! What a lovely name! I only knew papaya whip color, but now I love this song too.')
+Comment.create(user_id: 2, post_id: 2, content: 'Papaya is sweet.')

--- a/spec/factories/comments.rb
+++ b/spec/factories/comments.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :comment do
+    content { "MyText" }
+    association :user
+    association :post
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :user do
-    email { "user@test.com" }
+    sequence(:email) { |n| "test-#{n}@example.com" }
     password { "password" }
     password_confirmation { "password" }
   end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :user do
-    email { "user@random.com" }
+    email { "user@test.com" }
     password { "password" }
     password_confirmation { "password" }
   end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -1,0 +1,3 @@
+RSpec.describe Comment, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -1,3 +1,15 @@
 RSpec.describe Comment, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe 'is expected to have db columns' do
+    it { is_expected.to have_db_column :content }
+  end
+
+  describe 'is expected to have validation' do
+    it { is_expected.to validate_presence_of :content }
+  end
+
+  describe 'Factory Bot' do
+    it 'is expected to be valid' do
+      expect(create(:comment)).to be_valid
+    end
+  end
 end

--- a/spec/requests/api/user_can_create_a_post_spec.rb
+++ b/spec/requests/api/user_can_create_a_post_spec.rb
@@ -1,6 +1,7 @@
 RSpec.describe 'POST /api/posts', type: :request do
-  let(:user) { create(:user)}
-  let(:user_header) {user.create_new_auth_token}
+  let(:user) { create(:user) }
+  let(:user_header) { user.create_new_auth_token }
+  
   describe 'successfully create a post' do
     before do
       post '/api/posts',

--- a/spec/requests/api/user_can_leave_a_comment_spec.rb
+++ b/spec/requests/api/user_can_leave_a_comment_spec.rb
@@ -20,7 +20,26 @@ RSpec.describe 'POST /api/posts/:post_id/comments', type: :request do
     end
 
     it 'is expected to return the comment that was created' do
-      expect(existing_post.comments[0]['content']).to eq 'Awesome stuff!'
+      expect(response_json['comment']['content']).to eq 'Awesome stuff!'
+    end
+  end
+  describe 'unsuccessfully create a comment without content' do
+    before do
+      post "/api/posts/#{existing_post.id}/comments",
+           params: {
+             comment: {
+               post_id: existing_post.id,
+             }
+           },
+           headers: user_header
+    end
+
+    it 'is expected to return a 422 status' do
+      expect(response).to have_http_status 422
+    end
+
+    it 'is expected to return an error message' do
+      expect(response_json['message']).to eq "Content can't be blank"
     end
   end
 end

--- a/spec/requests/api/user_can_leave_a_comment_spec.rb
+++ b/spec/requests/api/user_can_leave_a_comment_spec.rb
@@ -1,0 +1,26 @@
+RSpec.describe 'POST /api/posts/:post_id/comments', type: :request do
+  let!(:existing_post) { create(:post) }
+  let(:user) { create(:user, email: 'new@user.com') }
+  let(:user_header) { user.create_new_auth_token }
+
+  describe 'successfully create a comment' do
+    before do
+      post "/api/posts/#{existing_post.id}/comments",
+           params: {
+             comment: {
+               content: 'Awesome stuff!',
+               post_id: existing_post.id,
+             }
+           },
+           headers: user_header
+    end
+
+    it 'is expected to return a 201 status' do
+      expect(response).to have_http_status 201
+    end
+
+    it 'is expected to return the comment that was created' do
+      expect(existing_post.comments[0]['content']).to eq 'Awesome stuff!'
+    end
+  end
+end


### PR DESCRIPTION
[User can comment on another post](https://www.pivotaltracker.com/story/show/176613368)

## User Story
```
As an API,            
In order to receive and display the comment on posts,         
I want to be able to update the posts in index
```

## Changes proposed in this pull request:
* Adding comment model and comments controller
* Writing a test
* Adding serializers and generating IndexSerializer for Post
* Adding validations of content to comments

## What I have learned working on this feature:
* The importance of configuring the right way

## Packages/Gems added
* active_model_serializers