### PR TITLE
User can delete their past post

### DIFF
--- a/app/controllers/api/posts_controller.rb
+++ b/app/controllers/api/posts_controller.rb
@@ -1,4 +1,6 @@
 class Api::PostsController < ApplicationController
+  before_action :authenticate_user!, only: [:destroy]
+
   def index
     posts = Post.order('created_at DESC')
     render json: posts, each_serializer: PostIndexSerializer
@@ -14,6 +16,13 @@ class Api::PostsController < ApplicationController
   end
 
   def destroy
+    post = Post.find(params[:post_id])
+    post.destroy
+    if post.persisted?
+      render json: { message: "OPS, your post wants to stay" }, status: 400
+    else
+      render json: { message: "Your post has been deleted!" }, status: 204
+    end
   end
 
   private

--- a/app/controllers/api/posts_controller.rb
+++ b/app/controllers/api/posts_controller.rb
@@ -1,5 +1,4 @@
 class Api::PostsController < ApplicationController
-
   def index
     posts = Post.order('created_at DESC')
     render json: posts, each_serializer: PostIndexSerializer
@@ -17,6 +16,8 @@ class Api::PostsController < ApplicationController
   def destroy
     Post.find(params[:post_id]).destroy!
     head :no_content
+  rescue StandardError => e
+    render json: { message: 'Oops, something went very wrong...' }, status: 404
   end
 
   private

--- a/app/controllers/api/posts_controller.rb
+++ b/app/controllers/api/posts_controller.rb
@@ -1,5 +1,4 @@
 class Api::PostsController < ApplicationController
-  before_action :authenticate_user!, only: [:destroy]
 
   def index
     posts = Post.order('created_at DESC')
@@ -16,13 +15,8 @@ class Api::PostsController < ApplicationController
   end
 
   def destroy
-    post = Post.find(params[:post_id])
-    post.destroy
-    if post.persisted?
-      render json: { message: "OPS, your post wants to stay" }, status: 400
-    else
-      render json: { message: "Your post has been deleted!" }, status: 204
-    end
+    Post.find(params[:post_id]).destroy!
+    head :no_content
   end
 
   private

--- a/app/controllers/api/posts_controller.rb
+++ b/app/controllers/api/posts_controller.rb
@@ -13,6 +13,9 @@ class Api::PostsController < ApplicationController
     end
   end
 
+  def destroy
+  end
+
   private
 
   def post_params

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   mount_devise_token_auth_for 'User', at: 'auth', controllers: { omniauth_callbacks: 'api/omniauth_callbacks' }
 
   namespace :api do
-    resources :posts, only: %i[index create] do
+    resources :posts, only: %i[index create destroy] do
       resources :comments, only: %i[create index]
       resources :likes, only: [:create]
     end

--- a/spec/requests/api/user_can_delete_their_post_spec.rb
+++ b/spec/requests/api/user_can_delete_their_post_spec.rb
@@ -15,5 +15,10 @@ RSpec.describe 'DELETE /api/posts/:post_id', type: :request do
     it 'is expected to return success message' do
       expect(response_json['message']).to eq "Your post has been deleted!"
     end
+
+    it 'is expected to not return a post'do
+      binding.pry
+      expect(Post).to eq []
+    end
   end
 end

--- a/spec/requests/api/user_can_delete_their_post_spec.rb
+++ b/spec/requests/api/user_can_delete_their_post_spec.rb
@@ -4,20 +4,21 @@ RSpec.describe 'DELETE /api/posts/:post_id', type: :request do
   let(:user_header) { user.create_new_auth_token }
   describe 'successfully delete their post' do
     before do
-      delete '/api/posts/:post_id',
+      delete "/api/posts/#{post.id}",
              params: {post_id: post.id},
              headers: user_header
     end
+
     it 'is expected to return a 204 status' do
       expect(response).to have_http_status 204
     end
 
-    it 'is expected to return success message' do
-      expect(response_json['message']).to eq "Your post has been deleted!"
+    it 'is expected to return a :no_content status' do
+      expect(response).to have_http_status :no_content
     end
 
     it 'is expected to not return a post'do
-      expect(Post).to eq []
+      expect(response.body).to eq ""
     end
   end
 end

--- a/spec/requests/api/user_can_delete_their_post_spec.rb
+++ b/spec/requests/api/user_can_delete_their_post_spec.rb
@@ -17,7 +17,6 @@ RSpec.describe 'DELETE /api/posts/:post_id', type: :request do
     end
 
     it 'is expected to not return a post'do
-      binding.pry
       expect(Post).to eq []
     end
   end

--- a/spec/requests/api/user_can_delete_their_post_spec.rb
+++ b/spec/requests/api/user_can_delete_their_post_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'DELETE /api/posts/:post_id', type: :request do
   describe 'successfully delete their post' do
     before do
       delete "/api/posts/#{post.id}",
-             params: {post_id: post.id},
+             params: { post_id: post.id },
              headers: user_header
     end
 
@@ -13,12 +13,8 @@ RSpec.describe 'DELETE /api/posts/:post_id', type: :request do
       expect(response).to have_http_status 204
     end
 
-    it 'is expected to return a :no_content status' do
-      expect(response).to have_http_status :no_content
-    end
-
-    it 'is expected to not return a post'do
-      expect(response.body).to eq ""
+    it 'is expected to not return a post' do
+      expect(response.body).to eq ''
     end
   end
 end

--- a/spec/requests/api/user_can_delete_their_post_spec.rb
+++ b/spec/requests/api/user_can_delete_their_post_spec.rb
@@ -1,0 +1,19 @@
+RSpec.describe 'DELETE /api/posts/:post_id', type: :request do
+  let!(:post) { create(:post) }
+  let(:user) { create(:user) }
+  let(:user_header) { user.create_new_auth_token }
+  describe 'successfully delete their post' do
+    before do
+      delete '/api/posts/:post_id',
+             params: {post_id: post.id},
+             headers: user_header
+    end
+    it 'is expected to return a 204 status' do
+      expect(response).to have_http_status 204
+    end
+
+    it 'is expected to return success message' do
+      expect(response_json['message']).to eq "Your post has been deleted!"
+    end
+  end
+end


### PR DESCRIPTION
[User can delete their past post](https://www.pivotaltracker.com/story/show/176626434)

## User Story
```
As an API,            
In order to keep the DB clean,
I want to delete posts from DB.
```

## Changes proposed in this pull request:
* Creating test
* Adding destroy route and action in post controller

## What I have learned working on this feature:
* How to make a delete request