### PR TITLE
User can unlike another post

### DIFF
--- a/app/controllers/api/likes_controller.rb
+++ b/app/controllers/api/likes_controller.rb
@@ -1,11 +1,16 @@
 class Api::LikesController < ApplicationController
   def create
-    if already_liked?
-      render json: { message: "You can't like more than once" }, status: 422
-    else
+    # if already_liked?
+    #   render json: { message: "You can't like more than once" }, status: 422
+    # else
     like = current_user.likes.create(like_params)
-    render status: 201 if like.persisted?
-    end
+    render status: 201 
+    # end
+  end
+
+  def destroy
+   likes = current_user.likes.destroy(like_params) if already_liked?
+   render status: 200
   end
 
   private

--- a/app/controllers/api/likes_controller.rb
+++ b/app/controllers/api/likes_controller.rb
@@ -11,7 +11,7 @@ class Api::LikesController < ApplicationController
   end
 
   def destroy
-      Like.destroy(find_like[:id])
+    Like.destroy(find_like[:id])
   end
 
   private

--- a/app/controllers/api/likes_controller.rb
+++ b/app/controllers/api/likes_controller.rb
@@ -4,7 +4,6 @@ class Api::LikesController < ApplicationController
   def create
     if already_liked?
       destroy
-      # render json: { message: "You can't like more than once" }, status: 422
     else
     like = current_user.likes.create(like_params)
     render status: 201 
@@ -12,19 +11,14 @@ class Api::LikesController < ApplicationController
   end
 
   def destroy
-    if already_liked?
-      render json: { message: "You can't destoy me!!!" }, status: 422
-    else 
-      @like = current_user.likes.find(params[:id])   #destroy(like_params) 
-      @like.destroy
-      # render status: 200
-    end
+      like = current_user.likes.destroy(like_params)
+      render status: 200
   end
 
   private
 
   def find_like
-    likes = Post.likes.find(params[:id])
+    Like.find(params[:id])
   end
 
   def like_params

--- a/app/controllers/api/likes_controller.rb
+++ b/app/controllers/api/likes_controller.rb
@@ -6,7 +6,7 @@ class Api::LikesController < ApplicationController
       destroy
     else
       like = current_user.likes.create(like_params)
-      render status: 201 
+      render status: 201 if like.persisted?
     end
   end
 

--- a/app/controllers/api/likes_controller.rb
+++ b/app/controllers/api/likes_controller.rb
@@ -5,14 +5,15 @@ class Api::LikesController < ApplicationController
     if already_liked?
       destroy
     else
-    like = current_user.likes.create(like_params)
-    render status: 201 
+      like = current_user.likes.create(like_params)
+      render status: 201 
     end
   end
 
   def destroy
-      like = current_user.likes.destroy(like_params)
-      render status: 200
+      Like.destroy(find_like[:id])
+      # like = current_user.likes.destroy(like_params)
+      # render status: 200
   end
 
   private

--- a/app/controllers/api/likes_controller.rb
+++ b/app/controllers/api/likes_controller.rb
@@ -1,19 +1,31 @@
 class Api::LikesController < ApplicationController
+  before_action :find_like, only: [:destroy] 
+
   def create
-    # if already_liked?
-    #   render json: { message: "You can't like more than once" }, status: 422
-    # else
+    if already_liked?
+      destroy
+      # render json: { message: "You can't like more than once" }, status: 422
+    else
     like = current_user.likes.create(like_params)
     render status: 201 
-    # end
+    end
   end
 
   def destroy
-   likes = current_user.likes.destroy(like_params) if already_liked?
-   render status: 200
+    if already_liked?
+      render json: { message: "You can't destoy me!!!" }, status: 422
+    else 
+      @like = current_user.likes.find(params[:id])   #destroy(like_params) 
+      @like.destroy
+      # render status: 200
+    end
   end
 
   private
+
+  def find_like
+    likes = Post.likes.find(params[:id])
+  end
 
   def like_params
     params.require(:like).permit(:user_id, :post_id)

--- a/app/controllers/api/likes_controller.rb
+++ b/app/controllers/api/likes_controller.rb
@@ -12,8 +12,6 @@ class Api::LikesController < ApplicationController
 
   def destroy
       Like.destroy(find_like[:id])
-      # like = current_user.likes.destroy(like_params)
-      # render status: 200
   end
 
   private

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
   namespace :api do
     resources :posts, only: %i[index create destroy] do
       resources :comments, only: %i[create index]
-      resources :likes, only: [:create]
+      resources :likes, only: [:create, :destroy]
     end
     resources :tracks, only: [:index]
     resources :users, only: [:show]

--- a/spec/requests/api/user_can_delete_their_post_spec.rb
+++ b/spec/requests/api/user_can_delete_their_post_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe 'DELETE /api/posts/:post_id', type: :request do
-  let!(:post) { create(:post) }
   let(:user) { create(:user) }
   let(:user_header) { user.create_new_auth_token }
+  let!(:post) { create(:post, user_id: user.id) }
   describe 'successfully delete their post' do
     before do
       delete "/api/posts/#{post.id}",
@@ -13,8 +13,8 @@ RSpec.describe 'DELETE /api/posts/:post_id', type: :request do
       expect(response).to have_http_status 204
     end
 
-    it 'is expected to not return a post' do
-      expect(response.body).to eq ''
+    it 'is expected to decrease post count back to 0' do
+      expect(Post.count).to eq 0
     end
   end
 end

--- a/spec/requests/api/user_can_like_another_post_spec.rb
+++ b/spec/requests/api/user_can_like_another_post_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe 'POST /api/posts/:post_id/likes', type: :request do
 
   describe 'successfully unlike a post' do
     let!(:existing_post) { create(:post) }
-    let!(:like) { create(:like) }
+    let!(:like) { create(:like, post_id: existing_post.id) }
     before do    
         delete "/api/posts/#{existing_post.id}/likes/#{like.id}",
              params: {
@@ -36,7 +36,7 @@ RSpec.describe 'POST /api/posts/:post_id/likes', type: :request do
              headers: user_header
     end
 
-    it 'is expected to return a 200 status' do
+    it 'is expected to return a 204 status' do
       expect(response).to have_http_status 204
     end
 

--- a/spec/requests/api/user_can_like_another_post_spec.rb
+++ b/spec/requests/api/user_can_like_another_post_spec.rb
@@ -24,16 +24,21 @@ RSpec.describe 'POST /api/posts/:post_id/likes', type: :request do
   end
 
   describe 'successfully unlike a post' do
-    before do
-      2.times do
+    before do    
         post "/api/posts/#{existing_post.id}/likes",
              params: {
                like: {
                  post_id: existing_post.id
                }
              },
+             headers: user_header,
+             delete "/api/posts/#{existing_post.id}/likes",
+             params: {
+               like: {
+                 post_id: existing_post.id
+               }
+             },
              headers: user_header
-      end
     end
 
     it 'is expected to return a 200 status' do
@@ -41,6 +46,8 @@ RSpec.describe 'POST /api/posts/:post_id/likes', type: :request do
     end
 
     it 'is expected to decrease like count back to 0' do
+
+      binding.pry
       expect(existing_post.likes.count).to eq 0
     end
   end

--- a/spec/requests/api/user_can_like_another_post_spec.rb
+++ b/spec/requests/api/user_can_like_another_post_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe 'POST /api/posts/:post_id/likes', type: :request do
     end
 
     it 'is expected to decrease like count back to 0' do
-      expect(Likes.count).to eq 0
+      expect(Like.count).to eq 0
     end
   end
 end

--- a/spec/requests/api/user_can_like_another_post_spec.rb
+++ b/spec/requests/api/user_can_like_another_post_spec.rb
@@ -24,15 +24,10 @@ RSpec.describe 'POST /api/posts/:post_id/likes', type: :request do
   end
 
   describe 'successfully unlike a post' do
+    let!(:existing_post) { create(:post) }
+    let!(:like) { create(:like) }
     before do    
-        post "/api/posts/#{existing_post.id}/likes",
-             params: {
-               like: {
-                 post_id: existing_post.id
-               }
-             },
-             headers: user_header,
-             delete "/api/posts/#{existing_post.id}/likes",
+        delete "/api/posts/#{existing_post.id}/likes/#{like.id}",
              params: {
                like: {
                  post_id: existing_post.id
@@ -46,8 +41,6 @@ RSpec.describe 'POST /api/posts/:post_id/likes', type: :request do
     end
 
     it 'is expected to decrease like count back to 0' do
-
-      binding.pry
       expect(existing_post.likes.count).to eq 0
     end
   end

--- a/spec/requests/api/user_can_like_another_post_spec.rb
+++ b/spec/requests/api/user_can_like_another_post_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe 'POST /api/posts/:post_id/likes', type: :request do
     end
 
     it 'is expected to decrease like count back to 0' do
-      expect(existing_post.likes.count).to eq 0
+      expect(Likes.count).to eq 0
     end
   end
 end

--- a/spec/requests/api/user_can_like_another_post_spec.rb
+++ b/spec/requests/api/user_can_like_another_post_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe 'POST /api/posts/:post_id/likes', type: :request do
     end
   end
 
-  describe 'unsuccessfully when user already liked the post' do
+  describe 'successfully unlike a post' do
     before do
       2.times do
         post "/api/posts/#{existing_post.id}/likes",
@@ -36,12 +36,12 @@ RSpec.describe 'POST /api/posts/:post_id/likes', type: :request do
       end
     end
 
-    it 'is expected to return a 422 status' do
-      expect(response).to have_http_status 422
+    it 'is expected to return a 200 status' do
+      expect(response).to have_http_status 200
     end
 
-    it 'is expected to return an error message' do
-      expect(response_json['message']).to eq "You can't like more than once"
+    it 'is expected to decrease like count back to 0' do
+      expect(existing_post.likes.count).to eq 0
     end
   end
 end

--- a/spec/requests/api/user_can_like_another_post_spec.rb
+++ b/spec/requests/api/user_can_like_another_post_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe 'POST /api/posts/:post_id/likes', type: :request do
     end
 
     it 'is expected to return a 200 status' do
-      expect(response).to have_http_status 200
+      expect(response).to have_http_status 204
     end
 
     it 'is expected to decrease like count back to 0' do


### PR DESCRIPTION
[User can unlike another post](https://www.pivotaltracker.com/story/show/176798583)

## User Story
```
As an API,            
In order to provide the client with the functionality to unlike a post,         
I want to able to have a destroy action.
```

## Changes proposed in this pull request:
* Adding destroy action in likes controller
* Adding route
* Creating test

## What I have learned working on this feature:
* To watch our for false-positive tests