### PR TITLE
[FIX]User can unlike another post

### DIFF
--- a/app/controllers/api/likes_controller.rb
+++ b/app/controllers/api/likes_controller.rb
@@ -1,24 +1,15 @@
 class Api::LikesController < ApplicationController
-  before_action :find_like, only: [:destroy] 
-
   def create
     if already_liked?
-      destroy
+      like = Like.where(user_id: current_user.id, post_id: params[:post_id])
+      Like.destroy(like.ids)
     else
       like = current_user.likes.create(like_params)
       render status: 201 if like.persisted?
     end
   end
 
-  def destroy
-    Like.destroy(find_like[:id])
-  end
-
   private
-
-  def find_like
-    Like.find(params[:id])
-  end
 
   def like_params
     params.require(:like).permit(:user_id, :post_id)

--- a/app/controllers/api/likes_controller.rb
+++ b/app/controllers/api/likes_controller.rb
@@ -3,6 +3,7 @@ class Api::LikesController < ApplicationController
     if already_liked?
       like = Like.where(user_id: current_user.id, post_id: params[:post_id])
       Like.destroy(like.ids)
+      render status: 204
     else
       like = current_user.likes.create(like_params)
       render status: 201 if like.persisted?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
   namespace :api do
     resources :posts, only: %i[index create destroy] do
       resources :comments, only: %i[create index]
-      resources :likes, only: [:create, :destroy]
+      resources :likes, only: [:create]
     end
     resources :tracks, only: [:index]
     resources :users, only: [:show]

--- a/spec/requests/api/user_can_like_another_post_spec.rb
+++ b/spec/requests/api/user_can_like_another_post_spec.rb
@@ -25,15 +25,16 @@ RSpec.describe 'POST /api/posts/:post_id/likes', type: :request do
 
   describe 'successfully unlike a post' do
     let!(:existing_post) { create(:post) }
-    let!(:like) { create(:like, post_id: existing_post.id) }
-    before do    
-        delete "/api/posts/#{existing_post.id}/likes/#{like.id}",
+    before do
+      2.times do
+        post "/api/posts/#{existing_post.id}/likes",
              params: {
                like: {
                  post_id: existing_post.id
                }
              },
              headers: user_header
+      end
     end
 
     it 'is expected to return a 204 status' do


### PR DESCRIPTION
[User can unlike another post](https://www.pivotaltracker.com/story/show/176798583)
## User Story
```
As an API,            
In order to provide the client with the functionality to unlike a post,         
I want to able to have a destroy action.
```
## Changes proposed in this pull request:
* Modifying create action in Likes controller
* Deleting destroy action and route
* Modifying user_can_like_another_post

