### PR TITLE
[FIX]User can delete their past post

### DIFF
--- a/app/controllers/api/posts_controller.rb
+++ b/app/controllers/api/posts_controller.rb
@@ -14,7 +14,7 @@ class Api::PostsController < ApplicationController
   end
 
   def destroy
-    Post.find(params[:post_id]).destroy!
+    Post.find(params[:id]).destroy!
     head :no_content
   rescue StandardError => e
     render json: { message: 'Oops, something went very wrong...' }, status: 404

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -2,6 +2,6 @@ class Post < ApplicationRecord
   validates_presence_of :track, :artists, :description
 
   belongs_to :user
-  has_many :comments
-  has_many :likes
+  has_many :comments, dependent: :destroy
+  has_many :likes, dependent: :destroy
 end

--- a/spec/requests/api/user_can_delete_their_post_spec.rb
+++ b/spec/requests/api/user_can_delete_their_post_spec.rb
@@ -1,12 +1,9 @@
 RSpec.describe 'DELETE /api/posts/:post_id', type: :request do
-  let(:user) { create(:user) }
-  let(:user_header) { user.create_new_auth_token }
-  let!(:post) { create(:post, user_id: user.id) }
+  let!(:post) { create(:post) }
   describe 'successfully delete their post' do
     before do
       delete "/api/posts/#{post.id}",
-             params: { post_id: post.id },
-             headers: user_header
+             params: { post_id: post.id }
     end
 
     it 'is expected to return a 204 status' do


### PR DESCRIPTION
## User story
```
As an API,            
In order to keep the DB clean,
I want to delete posts from DB.
```

## Changes proposed in this PR
* Adding `dependent: :destroy` in post model 
* Modifying user_can_delete_their_post_spec.rb
* Modfiying destroy action in posts controller